### PR TITLE
Updated cnpg image to testing image that allows tcp values

### DIFF
--- a/cnpg-operator.yaml
+++ b/cnpg-operator.yaml
@@ -11011,14 +11011,14 @@ spec:
         - /manager
         env:
         - name: OPERATOR_IMAGE_NAME
-          value: ghcr.io/cloudnative-pg/cloudnative-pg:1.16.0
+          value: ghcr.io/cloudnative-pg/cloudnative-pg-testing:main
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         - name: MONITORING_QUERIES_CONFIGMAP
           value: cnpg-default-monitoring
-        image: ghcr.io/cloudnative-pg/cloudnative-pg:1.16.0
+        image: ghcr.io/cloudnative-pg/cloudnative-pg-testing:main
         livenessProbe:
           httpGet:
             path: /readyz


### PR DESCRIPTION
Adjusted image to one that has new webhook deployed that allows tcp keepalive and timeout values to be configured on pooler.