### PR TITLE
Swap default pool sizes

### DIFF
--- a/overlays/prod2/cnpg-butler-pooler.yaml
+++ b/overlays/prod2/cnpg-butler-pooler.yaml
@@ -13,7 +13,7 @@ spec:
     poolMode: session
     parameters:
       max_client_conn: "1000"
-      default_pool_size: "800"
+      default_pool_size: "500"
       log_connections: "1"
       log_disconnections: "1"
       idle_transaction_timeout: "0"
@@ -129,7 +129,7 @@ spec:
     poolMode: transaction
     parameters:
       max_client_conn: "1000"
-      default_pool_size: "500"
+      default_pool_size: "800"
       log_connections: "1"
       log_disconnections: "1"
       idle_transaction_timeout: "0"


### PR DESCRIPTION
Since we are using the transaction pooler by default, make it the larger one.