### PR TITLE
add read only pooler transaction

### DIFF
--- a/overlays/prod/embargo16-prod/cnpg-butler-embargo16-pooler.yaml
+++ b/overlays/prod/embargo16-prod/cnpg-butler-embargo16-pooler.yaml
@@ -11,12 +11,12 @@ spec:
   pgbouncer:
     poolMode: transaction
     parameters:
-      max_client_conn: "2000"
-      default_pool_size: "1000"
+      max_client_conn: "4000"
+      default_pool_size: "3000"
       log_connections: "1"
       log_disconnections: "1"
       idle_transaction_timeout: "0"
-      server_idle_timeout: "0"
+      server_idle_timeout: "60"
       tcp_keepalive: "1"
       tcp_keepcnt: "1"
       tcp_keepidle: "1"
@@ -77,7 +77,7 @@ spec:
       labels:
         app: pooler
       annotations:
-        prometheus.io/scrape: 'true' 
+        prometheus.io/scrape: 'true'
     spec:
       containers:
       - name: pgbouncer


### PR DESCRIPTION
This was requested/suggested during several Campaign Management meetings, and was tested by Hsin-Fang from PP.  Currently that pooler is running under `sdf-rubin-ingest`
```
kubectl get poolers -n embargo16-prod
NAME                                          AGE    CLUSTER                 TYPE
usdf-butler-embargo16-pooler-session-rw       293d   usdf-butler-embargo16   rw
usdf-butler-embargo16-pooler-transaction-ro   14d    usdf-butler-embargo16   ro
usdf-butler-embargo16-pooler-transaction-rw   293d   usdf-butler-embargo16   rw
```

